### PR TITLE
正常にローカル環境が動作しない問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   {
     "start:product": "cross-env API_URL=https://api.kokasai.com webpack-cli serve --mode development",
     "start:dev": "cross-env API_URL=https://dev-api.kokasai.com webpack-cli serve --mode development",
-    "start:local": "cross-env API_URL=http://localhost:8081 webpack-cli serve --mode development",
+    "start:local": "cross-env API_URL=http://local-api.kokasai.com:8081 webpack-cli serve --mode development",
     "build:product": "cross-env API_URL=https://api.kokasai.com webpack",
     "build:dev": "cross-env API_URL=https://dev-api.kokasai.com webpack",
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,5 +52,8 @@ module.exports = {
         new webpack.DefinePlugin({
             'process.env.API_URL' : '\'' + process.env.API_URL + '\'',
         })
-    ]
+    ],
+    devServer: {
+        historyApiFallback: true
+    }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,8 @@ module.exports = {
         })
     ],
     devServer: {
-        historyApiFallback: true
+        historyApiFallback: true,
+        host: 'local-panel.kokasai.com',
+        port: 8080
     }
 };


### PR DESCRIPTION
- devServer の影響で再読み込み時に `cannot get /` が出る
- panel と api のアドレスが共通になっていてCookieが保存されない。ドメインを割り当てることで対応
    - panel → local-panel
    - api → local-api