### PR TITLE
perf: 不要なクッキー保存を削除

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -8,9 +8,8 @@ export const URL = process.env.API_URL;
 /**
  * ログイン認証されているか取得する。
  * [GET /auth](https://github.com/gKokasai/api.kokasai.com/blob/master/DOCUMENT.md#get-auth)
- * @param cookie セッションのCookie
  */
-export const getAuth = (cookie: string): Promise<AxiosResponse<never>> => axios.get(`${URL}/auth`, { headers: { cookie } });
+export const getAuth = (): Promise<AxiosResponse<never>> => axios.get(`${URL}/auth`);
 
 /**
  * ログイン認証する。

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -49,23 +49,16 @@ const Login: FC = () => {
 
   useEffect(
     () => {
-      let isLoggedIn = auth.user?.isLoggedIn === true;
-      if (!isLoggedIn) {
-        const cookie = document.cookie.split('; ').find((line: string) => line.startsWith('auth='));
-        if (cookie) {
-          const checkSession = async () => {
-            const result = await api.getAuth(cookie);
-            if (result.status === 200) {
-              auth.setUser({ ...auth.user, isLoggedIn: true });
-              isLoggedIn = true;
-            } else if (result.status === 401) {
-              document.cookie = 'auth=; max-age=0';
-            }
-          };
-          checkSession();
-        }
+      if (!auth.user?.isLoggedIn && !auth.user?.isFailSessionLogin) {
+        api.getAuth().then((result) => {
+          if (result.status === 200) {
+            auth.setUser({ ...auth.user, isLoggedIn: true });
+          }
+        }).catch(() => {
+          auth.setUser({ ...auth.user, isFailSessionLogin: true })
+        });
       }
-    }, [],
+    },
   );
   if (auth.user?.isLoading === true) {
     return (

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -4,6 +4,7 @@ import * as api from '../api';
 type User = {
   inputId?: string;
   inputPassWord?: string;
+  isFailSessionLogin?: boolean;
   isLoggedIn?: boolean;
   isLoading?: boolean;
   postedId?: boolean;
@@ -56,7 +57,6 @@ const useAuthCtx = (): authContextType => {
         setUser({
           ...user, isLoading: false, isLoggedIn: true, statusCode: { login: res.status },
         });
-        document.cookie = `auth=${res.data.auth}`;
         console.log(res);
       })
       .catch((err) => {


### PR DESCRIPTION
セッションクッキーが必要な他のAPIリクエストではクッキーを指定せずに実行できている。そのため、 api.kokasai.com 側のクッキーに保存されており、それを利用できると考えられる。これまでの環境だと２つセッションを保存していた。

実際にローカル環境で試したところ、正常にセッションログインが行われた。Netlify のプレビューサイトだとクッキーの保存が正常に行われないのでローカル環境で試す必要がある。