### PR TITLE
ログインしてないユーザーにはLoadingを表示するようにした

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,15 +5,19 @@ import {
 import Login from './pages/Login';
 import Index from './pages/Index';
 import Document from './pages/Document';
-import { AuthProvider, checkSession, useAuth } from '../contexts/UserContext';
+import {
+  AuthProvider, checkSession, isShowEmptyPanel, useAuth
+} from '../contexts/UserContext';
 import { Pages } from '../pages';
 import Empty from './pages/Empty';
+import Loading from './organisms/login/Loading';
 
 const PrivateRoute: React.FC<RouteProps> = ({ ...props }) => {
   const auth = useAuth();
   if (!auth.user?.isLoggedIn && !auth.user?.isFailSessionLogin) {
     checkSession(auth);
-    return <Empty />;
+    if (isShowEmptyPanel()) return <Empty />;
+    return <Loading />;
   }
   if (auth.user?.isLoggedIn) {
     // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -24,6 +24,10 @@ type Props = {
   children: ReactNode;
 }
 
+const ShowEmptyPanelKey = 'show-empty-panel';
+
+export const isShowEmptyPanel = (): boolean => localStorage.getItem(ShowEmptyPanelKey) != null
+
 const createCtx = <ContextType extends unknown>() => {
   const ctx = React.createContext<ContextType | undefined>(undefined);
   const useCtx = () => {
@@ -54,11 +58,13 @@ const useAuthCtx = (): authContextType => {
     setUser({ ...user, isLoading: true });
     api.postAuth(user?.inputId, user?.inputPassWord)
       .then((res) => {
+        localStorage.setItem(ShowEmptyPanelKey, '');
         setUser({
           ...user, isLoading: false, isLoggedIn: true, statusCode: { login: res.status },
         });
       })
       .catch((err) => {
+        localStorage.removeItem(ShowEmptyPanelKey);
         setUser({ ...user, isLoading: false, statusCode: { login: err.response.status } });
       });
   };


### PR DESCRIPTION
ログインしているはずがないにも関わらず、空のコントロールパネルが表示されてしまっていた。

ローカルストレージの内容によって

- 空のコントロールパネル
- ロード中のログインフォーム

というように表示を変えるようにした