### PR TITLE
一覧からドキュメントにアクセスできない問題を修正

### DIFF
--- a/src/components/organisms/document/DocumentList.tsx
+++ b/src/components/organisms/document/DocumentList.tsx
@@ -28,7 +28,7 @@ const DocumentList: FC<DocumentListProps> = (props): JSX.Element => {
         onComplete={(_items) => (
           _items.map(
             (name) => (
-              <InternalLink to={`${Pages.document.href}?${name}`} key={name}>
+              <InternalLink to={`${Pages.documentName.href}?${name}`} key={name}>
                 <ListItem className={classes.listItem}>
                   <ListItemIcon>
                     <Description />


### PR DESCRIPTION
ドキュメント一覧とドキュメントへのアクセスを別のリンクにした時に変更し忘れていました