### PR TITLE
画面遷移時に再アクセスが発生する問題を修正

### DIFF
--- a/src/components/pages/NotFound.tsx
+++ b/src/components/pages/NotFound.tsx
@@ -1,8 +1,10 @@
 import React, { FC } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core';
 import * as icons from '@material-ui/icons';
+import { useHistory } from 'react-router-dom';
 import Typography from '../atoms/Typography';
 import Button from '../atoms/Button';
+import { Pages } from '../../pages';
 
 const NotFoundStyle = makeStyles((theme: Theme) => createStyles({
   container: {
@@ -33,6 +35,7 @@ const NotFoundStyle = makeStyles((theme: Theme) => createStyles({
 
 const NotFound: FC = (): JSX.Element => {
   const classes = NotFoundStyle();
+  const history = useHistory();
   return (
     <div className={classes.container}>
       <icons.MoodBad className={classes.icon} />
@@ -42,7 +45,7 @@ const NotFound: FC = (): JSX.Element => {
       <Typography variant="body1" align="center">
         ページが見つかりませんでした
       </Typography>
-      <Button onClick={() => { window.location.href = '/'; }} className={classes.button}>
+      <Button onClick={() => history.push(Pages.index.href)} className={classes.button}>
         <icons.ArrowBack className={classes.arrowBack} />
         トップに戻る
       </Button>

--- a/src/components/pages/document/DocumentName.tsx
+++ b/src/components/pages/document/DocumentName.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
 import { Pages } from '../../../pages';
 import { getDocument } from '../../../api/api';
 import { useAlert } from '../../../contexts/AlertContext';
@@ -6,6 +7,7 @@ import { useAlert } from '../../../contexts/AlertContext';
 const DocumentName: FC = (): JSX.Element => {
   const alert = useAlert();
   const queryParameter = window.location.search;
+  const history = useHistory();
   useEffect(() => {
     if (queryParameter) {
       getDocument(queryParameter.substring(1)).then((response) => {
@@ -15,18 +17,15 @@ const DocumentName: FC = (): JSX.Element => {
         const maxCount = 30;
         let count = 1;
         const backTime = 3000;
-        const { href } = window.location;
+        const { location } = history;
         alert.error('資料の取得に失敗しました', backTime);
-        let intervalId: number;
-        // eslint-disable-next-line prefer-const
-        intervalId = window.setInterval(() => {
-          const sameLocation = window.location.href === href;
+        const intervalId = window.setInterval(() => {
           if (count === maxCount) {
             window.clearInterval(intervalId);
-            window.location.href = Pages.document.href;
+            history.push(Pages.document.href);
             return;
           }
-          if (!sameLocation) {
+          if (history.location !== location) {
             window.clearInterval(intervalId);
             alert.close();
             return;
@@ -35,7 +34,7 @@ const DocumentName: FC = (): JSX.Element => {
         }, backTime / maxCount);
       });
     } else {
-      window.location.replace(Pages.document.href);
+      history.replace(Pages.document.href);
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
   return <></>;


### PR DESCRIPTION
window.location.href を使うと読み込みが発生し、

- 404.html
- index.html
- 該当ページへのアクセス

という流れになりますが、useHistory を使うと InternalLink のような動作をしてくれます。

---

https://github.com/gKokasai/panel.kokasai.com/blob/da514a5c6e1ec4ea9804075c5c60989a700b6fd3/src/components/pages/document/DocumentName.tsx#L13-L16
また、以上については、blob URLへのアクセスなので、history.replace を使ってはいけません。