### PR TITLE
deploy.yaml の実行速度をはやくした

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,13 +12,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - name: Cache dependencies
-        uses: actions/cache@v1
+      - name: Cache node_modules
+        uses: actions/cache@v2
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: |
+            node_modules
+          key: node-v${{ matrix.node-version }}-deps-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
       - name: install
         run: yarn
       - name: build


### PR DESCRIPTION
- actions/cache のバージョンを更新
- node_modules をキャッシュする方がはやい
    - [sya-ri.github.io](https://github.com/sya-ri/sya-ri.github.io/actions) で使用したところ、依存関係のインストールにかかる時間は 0~1秒程になった
    - [panel.kokasai.com](https://github.com/gKokasai/panel.kokasai.com/actions/workflows/deploy.yaml) の実行時間は 45秒程度である